### PR TITLE
Update addon branding to Blender Synthetic Data Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blender Synthetic Data Capture
 
-GS Capture Pro is a Blender addon for capturing synthetic training datasets for 3D Gaussian Splatting and NeRF pipelines.
+Blender Synthetic Data Capture is a Blender addon for capturing synthetic training datasets for 3D Gaussian Splatting and NeRF pipelines.
 
 ## Documentation
 
@@ -12,7 +12,7 @@ GS Capture Pro is a Blender addon for capturing synthetic training datasets for 
 1. Download the addon zip from Releases (or build with `python3 scripts/package_addon.py`).
 2. In Blender open `Edit -> Preferences -> Add-ons`.
 3. Click `Install...` and select the zip.
-4. Enable `GS Capture - Gaussian Splatting Training Data Generator`.
+4. Enable `Blender Synthetic Data Capture`.
 
 ## Branches
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# GS Capture Documentation
+# Blender Synthetic Data Capture Documentation
 
-GS Capture is a Blender addon for generating synthetic training data for 3D Gaussian Splatting and NeRF workflows.
+Blender Synthetic Data Capture is a Blender addon for generating synthetic training data for 3D Gaussian Splatting and NeRF workflows.
 
 This site is the user-facing documentation for installation, capture workflows, export formats, and training backend setup.
 
@@ -22,4 +22,3 @@ This site is the user-facing documentation for installation, capture workflows, 
 2. [Quick Start](quickstart.md)
 3. [Capture And Exports](capture-and-exports.md)
 4. [Training Backends](training-backends.md)
-

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,11 +11,11 @@
 1. Open Blender.
 2. Go to `Edit -> Preferences -> Add-ons`.
 3. Click `Install...` and select `gs_capture_addon-<version>.zip`.
-4. Enable `GS Capture - Gaussian Splatting Training Data Generator`.
+4. Enable `Blender Synthetic Data Capture`.
 
 ## Optional Backend Preferences
 
-Open `Edit -> Preferences -> Add-ons -> GS Capture`.
+Open `Edit -> Preferences -> Add-ons -> Blender Synthetic Data Capture`.
 
 Set paths/env names only for backends you plan to use:
 
@@ -36,4 +36,3 @@ Set paths/env names only for backends you plan to use:
 1. In 3D Viewport press `N`.
 2. Open the `GS Capture` tab.
 3. Confirm capture panels load without errors.
-

--- a/gs_capture_addon/__init__.py
+++ b/gs_capture_addon/__init__.py
@@ -3,7 +3,7 @@
 # Generates training images for 3D Gaussian Splatting from Blender scenes
 
 """
-GS Capture - Gaussian Splatting Training Data Generator
+Blender Synthetic Data Capture
 
 A professional-grade Blender addon for generating training data
 for Gaussian Splatting and NeRF models.
@@ -20,12 +20,12 @@ Features:
 """
 
 bl_info = {
-    "name": "GS Capture - Gaussian Splatting Training Data Generator",
+    "name": "Blender Synthetic Data Capture",
     "author": "Alexander Klaus",
     "version": (2, 2, 1),
     "blender": (4, 0, 0),
     "location": "View3D > Sidebar > GS Capture",
-    "description": "Professional training data generator for 3D Gaussian Splatting with scene analysis, presets, and validation",
+    "description": "Synthetic multi-view dataset generator for Gaussian Splatting and NeRF (RGB, depth, normals, masks, COLMAP, transforms.json)",
     "category": "Render",
     "doc_url": "https://github.com/klausi3D/blender-synthetic-data-capture",
     "tracker_url": "https://github.com/klausi3D/blender-synthetic-data-capture/issues",

--- a/gs_capture_addon/docs/USER_GUIDE.md
+++ b/gs_capture_addon/docs/USER_GUIDE.md
@@ -1,6 +1,6 @@
-# GS Capture - User Guide
+# Blender Synthetic Data Capture - User Guide
 
-GS Capture is a Blender addon for generating training data for 3D Gaussian Splatting and NeRF workflows. It produces camera-synchronized images and optional exports such as COLMAP files, depth maps, normals, and masks.
+Blender Synthetic Data Capture is a Blender addon for generating training data for 3D Gaussian Splatting and NeRF workflows. It produces camera-synchronized images and optional exports such as COLMAP files, depth maps, normals, and masks.
 
 ## Table of Contents
 
@@ -30,7 +30,7 @@ GS Capture is a Blender addon for generating training data for 3D Gaussian Splat
 
 1. In Blender: Edit -> Preferences -> Add-ons
 2. Click Install... and select `gs_capture_addon-<version>.zip` (or your packaged addon zip)
-3. Enable "GS Capture - Gaussian Splatting Training Data Generator"
+3. Enable "Blender Synthetic Data Capture"
 4. Optional: configure training backends in the add-on preferences
 
 ### Training Backend Preferences (Optional)


### PR DESCRIPTION
Summary:\n- rename addon display name in bl_info to Blender Synthetic Data Capture\n- update install-facing docs and guides to use the new addon name\n- keep UI panel location label (GS Capture tab) unchanged for continuity\n\nFiles:\n- gs_capture_addon/__init__.py\n- README.md\n- docs/index.md\n- docs/install.md\n- gs_capture_addon/docs/USER_GUIDE.md\n\nValidation:\n- package_addon.py built successfully