### PR TITLE
fix: harden beta release readiness and release gating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,172 @@ permissions:
   contents: write
 
 jobs:
+  verify-tag-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate tag matches addon version
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          init_path = Path("gs_capture_addon/__init__.py")
+          text = init_path.read_text(encoding="utf-8")
+          match = re.search(r'"version"\s*:\s*\((\d+),\s*(\d+),\s*(\d+)\)', text)
+          if not match:
+              raise SystemExit(f"Could not parse addon version from {init_path}")
+
+          version = ".".join(match.groups())
+          tag = os.environ.get("GITHUB_REF_NAME", "")
+          ref = os.environ.get("GITHUB_REF", "")
+
+          if ref.startswith("refs/tags/"):
+              expected = f"v{version}"
+              if tag != expected:
+                  raise SystemExit(
+                      f"Tag/version mismatch: tag={tag!r}, addon version={version!r}. "
+                      f"Expected tag {expected!r}."
+                  )
+              print(f"OK: tag {tag} matches addon version {version}")
+          else:
+              print(f"Workflow not running on a tag ({ref}); version check skipped.")
+          PY
+
+  python-sanity:
+    runs-on: ubuntu-latest
+    needs: verify-tag-version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile addon Python
+        run: |
+          python - <<'PY'
+          import os
+          for dp, _, files in os.walk("gs_capture_addon"):
+              for f in files:
+                  if f.endswith(".py"):
+                      p = os.path.join(dp, f)
+                      with open(p, "r", encoding="utf-8") as fh:
+                          compile(fh.read(), p, "exec")
+          print("OK: addon python compile")
+          PY
+
+      - name: Package addon
+        run: |
+          python tools/package_addon.py
+          ls -lh dist/
+
+  blender-smoke-windows:
+    runs-on: windows-latest
+    needs: python-sanity
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - blender_version: "4.5.1"
+            blender_series: "Blender4.5"
+            artifact_suffix: "4-5"
+          - blender_version: "5.0.0"
+            blender_series: "Blender5.0"
+            artifact_suffix: "5-0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Blender ${{ matrix.blender_version }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $version = "${{ matrix.blender_version }}"
+          $series = "${{ matrix.blender_series }}"
+          $url = "https://download.blender.org/release/$series/blender-$version-windows-x64.zip"
+          $zipPath = Join-Path $env:RUNNER_TEMP "blender-$version.zip"
+          $extractDir = Join-Path $env:RUNNER_TEMP "blender-$version"
+          Invoke-WebRequest -Uri $url -OutFile $zipPath
+          Expand-Archive -Path $zipPath -DestinationPath $extractDir
+          $blenderExe = Get-ChildItem -Path $extractDir -Recurse -Filter blender.exe | Select-Object -First 1
+          if (-not $blenderExe) { throw "blender.exe not found after extraction" }
+          "BLENDER_EXE=$($blenderExe.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Run release smoke verification
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & "$env:BLENDER_EXE" --factory-startup --python (Join-Path $pwd "tests/smoke/smoke_release_verification.py")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run checkpoint-only smoke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & "$env:BLENDER_EXE" --factory-startup --python (Join-Path $pwd "tests/smoke/smoke_checkpoint_resume_only.py")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run object-index mask smoke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & "$env:BLENDER_EXE" --factory-startup --python (Join-Path $pwd "tests/smoke/smoke_object_index_mask.py")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run coverage edge-case smoke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & "$env:BLENDER_EXE" --factory-startup --python (Join-Path $pwd "tests/smoke/smoke_coverage_edge_cases.py")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run COLMAP binary smoke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & "$env:BLENDER_EXE" --factory-startup --python (Join-Path $pwd "tests/smoke/smoke_colmap_binary_export.py")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run import-trained-splat smoke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          & "$env:BLENDER_EXE" --factory-startup --python (Join-Path $pwd "tests/smoke/smoke_import_trained_splat.py")
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Verify smoke reports
+        run: python tests/smoke/verify_ci_smoke_reports.py
+
+      - name: Upload smoke reports and outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: blender-smoke-${{ matrix.artifact_suffix }}
+          path: training_out/smoke_feature_verification
+          if-no-files-found: error
+
   package-and-publish:
     runs-on: ubuntu-latest
+    needs:
+      - verify-tag-version
+      - python-sanity
+      - blender-smoke-windows
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,11 +26,10 @@
 
 ## Path Too Long On Windows
 
-- Use short output roots, for example `C:\gs_capture\scene01`.
+- Use short output roots, for example `C:\<capture_root>\scene01`.
 - Avoid deep nested directories in output location.
 
 ## Backend Not Found
 
 - Re-check addon preference paths and conda env names.
 - Verify required scripts exist (`train.py`, `main.py`, `simple_trainer.py`).
-

--- a/gs_capture_addon/docs/BRANCHING_AND_CI.md
+++ b/gs_capture_addon/docs/BRANCHING_AND_CI.md
@@ -29,10 +29,13 @@ It runs on push/PR to `main` and `release/**`:
 - compile all addon Python files
 - package addon zip (`tools/package_addon.py`)
 
-2. Blender smoke tests on Windows (Blender 4.5.1):
+2. Blender smoke tests on Windows (Blender matrix: 4.5.1 and 5.0.0):
 - `tests/smoke/smoke_release_verification.py`
 - `tests/smoke/smoke_checkpoint_resume_only.py`
 - `tests/smoke/smoke_object_index_mask.py`
+- `tests/smoke/smoke_coverage_edge_cases.py`
+- `tests/smoke/smoke_colmap_binary_export.py`
+- `tests/smoke/smoke_import_trained_splat.py`
 - report validation with `tests/smoke/verify_ci_smoke_reports.py`
 
 Artifacts:
@@ -47,7 +50,12 @@ Workflow file: `.github/workflows/release.yml`
 - manual (`workflow_dispatch`)
 - git tag push matching `v*` (for example `v2.2.2`)
 
-2. Actions:
+2. Release gates (must pass before publish):
+- verify git tag matches addon `bl_info` version (for tag-triggered runs)
+- python sanity checks + packaging
+- Blender smoke matrix (4.5.1 and 5.0.0)
+
+3. Actions after gates:
 - build addon zip
 - upload artifact
 - publish GitHub release with zip attachment (tag-triggered runs)
@@ -58,7 +66,7 @@ Set branch protection on `release/4.5-lts` and `main`:
 
 1. Require status checks:
 - `python-sanity`
-- `blender-smoke-windows-4-5`
+- `blender-smoke-windows`
 
 2. Require pull request reviews.
 3. Restrict direct pushes.

--- a/gs_capture_addon/docs/USER_GUIDE.md
+++ b/gs_capture_addon/docs/USER_GUIDE.md
@@ -240,7 +240,7 @@ Depth and mask entries are only included when those exports are enabled.
   - For object-index masks, assign pass indices and use Object Index source
 
 - Path too long on Windows
-  - Use a shorter output path (e.g., `C:\gs_capture`) and avoid deep folder trees
+  - Use a shorter output path (e.g., `C:\<capture_root>`) and avoid deep folder trees
 
 ---
 

--- a/pipeline_config_example.yaml
+++ b/pipeline_config_example.yaml
@@ -51,7 +51,7 @@ training:
   implementation: "original"
   
   # Paths to implementations (auto-detected if empty)
-  gaussian_splatting_path: ""  # e.g., "/home/user/gaussian-splatting"
+  gaussian_splatting_path: ""  # e.g., "~/gaussian-splatting" or "<path-to>/gaussian-splatting"
   nerfstudio_path: ""
   gsplat_path: ""
   

--- a/tools/generate_initial_points.py
+++ b/tools/generate_initial_points.py
@@ -111,7 +111,8 @@ def write_colmap_points_binary(points, output_path, colors=None):
 
 def main():
     if len(sys.argv) < 2:
-        capture_dir = r"C:\Projects\GS_Blender\capture"
+        capture_dir = os.path.join(os.getcwd(), "capture")
+        print(f"No capture directory argument provided. Using default: {capture_dir}")
     else:
         capture_dir = sys.argv[1]
 
@@ -167,9 +168,9 @@ def main():
     write_colmap_points_binary(all_points, points_bin_path, colors)
 
     print("Done! Initial point cloud generated.")
-    print(f"\nTo train with LichtFeld Studio:")
-    print(f'  cd C:\\Projects\\GS_Tools\\LichtFeld-Studio\\build')
-    print(f'  .\\LichtFeld-Studio.exe -d "{capture_dir}" -o "{capture_dir}\\output" --strategy mcmc -i 30000')
+    print("\nExample training command (LichtFeld Studio):")
+    print("  cd <LICHTFELD_STUDIO_BUILD_DIR>")
+    print(f'  .\\LichtFeld-Studio.exe -d "{capture_dir}" -o "{os.path.join(capture_dir, "output")}" --strategy mcmc -i 30000')
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- harden training startup by using normalized preflight paths and robust extra-arg parsing
- harden training stop behavior by terminating full process trees cross-platform
- make checkpoint resume strict by validating expected output files before skipping completed indices
- add safe directory creation/reporting in capture/export flows to avoid uncaught path/permission crashes
- sanitize docs/tool examples to remove local machine-specific paths
- gate release publishing behind version/tag validation plus python + Blender smoke verification

## Validation
- python compile sanity for addon/tests/tools
- packaged addon zip via `tools/package_addon.py`
- Blender 5.0 smoke run: `tests/smoke/smoke_release_verification.py`
- smoke report validator: `tests/smoke/verify_ci_smoke_reports.py`

## Notes
- large local untracked folders (`apps/`, `gaussian-splatting/`, `gsplat/`, `training_out/`) were intentionally not included in this PR
